### PR TITLE
feat: add `safelist` option

### DIFF
--- a/lib/processStyleTags.js
+++ b/lib/processStyleTags.js
@@ -9,6 +9,7 @@ const processStyleTags = (node, tree, options = {}) => {
     const selectorsToRemove = new Set()
 
     const { postcss: { plugins, ...postcssOptions } } = options
+    const safelist = options.safelist || []
 
     // Ensure node.content is array
     node.content = Array.isArray(node.content) ? node.content : [node.content]
@@ -23,6 +24,10 @@ const processStyleTags = (node, tree, options = {}) => {
         const sortedCssNodes = sortCssNodesBySpecificity(result.root.nodes)
 
         sortedCssNodes.map(cssNode => {
+          if (safelist.includes(cssNode.selector)) {
+            return
+          }
+
           return tree.match(matchHelper(cssNode.selector), htmlNode => {
             extendStyle(htmlNode, cssNode, options)
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ TODO:
 - [x] Remove inlined classes from HTML elements
 - [x] Support PostCSS plugins
 - [ ] Support [complex selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) *
-- [ ] Safelist (selectors that should not be inlined)
+- [x] Safelist (selectors that should not be inlined)
 - [ ] Remove [orphaned selectors](https://github.com/cossssmin/posthtml-css-inline/issues/7)
 - [ ] Juice-compatible options
   - [ ] `excludedProperties`
@@ -107,6 +107,7 @@ You may configure how inlining works by passing an options object to the plugin.
 | `preserveImportant` | `boolean` | `false` | Preserve `!important` in the inlined CSS value. |
 | `removeInlinedSelectors` | `boolean` | `false` | Remove selectors that were successfully inlined from both the `<style>` tag and from the HTML body. |
 | `postcss` | `object` | `{}` | Object to configure PostCSS. |
+| `safelist` | `array` | `[]` | Array of selectors that should not be inlined. |
 
 ### `processLinkTags`
 
@@ -293,6 +294,55 @@ Result:
 </style>
 
 <p class="text-sm" style="font-size: 12px">small text</p>
+```
+
+### `safelist`
+
+Type: `array`\
+Default: `[]`
+
+Array of selectors that should not be inlined.
+
+> [!NOTE]  
+> The CSS `*` selector is not supported when inlining, you don't need to worry about safelisting it.
+
+```js
+import posthtml from'posthtml'
+import inlineCss from'posthtml-css-inline'
+
+posthtml([
+  inlineCss({
+    safelist: ['body', '.flex']
+  })
+])
+  .process(`
+    <style>
+      .flex {
+        display: flex;
+      }
+
+      body {
+        color: blue;
+      }
+
+      p {
+        color: red;
+      }
+    </style>
+
+    <body>
+      <p class="flex">small text</p>
+    </body>
+  `)
+  .then(result => result.html)
+```
+
+Result:
+
+```html
+<body>
+  <p class="flex" style="color: red">small text</p>
+</body>
 ```
 
 [npm]: https://www.npmjs.com/package/posthtml-css-inline

--- a/test/expected/safelist.html
+++ b/test/expected/safelist.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .flex {
+      display: flex;
+    }
+
+    body {
+      color: blue;
+    }
+
+    h1 {
+      text-transform: uppercase;
+    }
+
+    p {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+  <h1 style="text-transform: uppercase">Heading</h1>
+  <p class="flex" style="color: red">Content</p>
+</body>
+</html>

--- a/test/fixtures/safelist.html
+++ b/test/fixtures/safelist.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .flex {
+      display: flex;
+    }
+
+    body {
+      color: blue;
+    }
+
+    h1 {
+      text-transform: uppercase;
+    }
+
+    p {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+  <h1>Heading</h1>
+  <p class="flex">Content</p>
+</body>
+</html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,3 +70,9 @@ test('PostCSS plugins', () => {
     },
   })
 })
+
+test('Safelist', () => {
+  return process('safelist', {
+    safelist: ['body', '.flex']
+  })
+})


### PR DESCRIPTION
This PR adds a `safelist` option which may be used to define an array of CSS selectors that should not be inlined.

The `*` selector is not supported at all when inlining, no need to safelist it.

_Currently_, complex selectors such as `body p` aren't inlined either, no need to safelist those. Hopefully these will be supported by the time we release `v1.0.0`.

```js
posthtml([
  inlineCss({
    safelist: ['body', '.flex']
  })
]).process(html)
```