### PR TITLE
feat: skip css inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TODO:
 - [ ] Support [complex selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#complex_selector) *
 - [x] Safelist (selectors that should not be inlined)
 - [ ] Remove [orphaned selectors](https://github.com/cossssmin/posthtml-css-inline/issues/7)
-- [ ] [Skip inlining](https://github.com/cossssmin/posthtml-css-inline/issues/9) on marked tags
+- [x] [Skip inlining](https://github.com/cossssmin/posthtml-css-inline/issues/9) on marked tags
 - [ ] Juice-compatible options
   - [ ] `excludedProperties`
   - [ ] `resolveCSSVariables`
@@ -103,11 +103,19 @@ You may configure how inlining works by passing an options object to the plugin.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `processLinkTags` | `boolean` | `false` | Process `<link rel="stylesheet">` tags. |
-| `preserveImportant` | `boolean` | `false` | Preserve `!important` in the inlined CSS value. |
-| `removeInlinedSelectors` | `boolean` | `false` | Remove selectors that were successfully inlined from both the `<style>` tag and from the HTML body. |
-| `postcss` | `object` | `{}` | Object to configure PostCSS. |
-| `safelist` | `array` | `[]` | Array of selectors that should not be inlined. |
+| [`processLinkTags`](#processLinkTags) | `boolean` | `false` | Process `<link rel="stylesheet">` tags. |
+| [`preserveImportant`](#preserveimportant) | `boolean` | `false` | Preserve `!important` in the inlined CSS value. |
+| [`removeInlinedSelectors`](#removeinlinedselectors) | `boolean` | `false` | Remove selectors that were successfully inlined from both the `<style>` tag and from the HTML body. |
+| [`postcss`](#postcss) | `object` | `{}` | Object to configure PostCSS. |
+| [`safelist`](#safelist) | `array` | `[]` | Array of selectors that should not be inlined. |
+
+## Attributes
+
+You may configure how inlining works on a per-element basis.
+
+| Attribute | Description |
+| --- | --- |
+| [`no-inline`](#no-inline) | Skip inlining on this element. |
 
 ### `processLinkTags`
 
@@ -344,6 +352,73 @@ Result:
   <p class="flex" style="color: red">small text</p>
 </body>
 ```
+
+### `no-inline`
+
+You may use the `no-inline` attribute on an element to prevent CSS inlining.
+
+- when used on a `<style>` or `<link>` tag, the CSS inside the tag will not be inlined
+- when used on any other tag, the inliner will not inline CSS on that tag
+
+You may use any of the following attributes to achieve this on a `<style>` or `<link>` tag:
+
+- `no-inline`
+- `data-embed`
+- `embed`
+- `prevent-inline`
+- `skip-inline`
+
+Likewise, you may use any of the following attributes to achieve this on any other tag:
+
+- `no-inline`
+- `prevent-inline`
+- `skip-inline`
+
+The attribute will be removed from the tag in the resulting HTML.
+
+```js
+import posthtml from'posthtml'
+import inlineCss from'posthtml-css-inline'
+
+posthtml([
+  inlineCss()
+])
+  .process(`
+    <style no-inline>
+      p {
+        font-size: 12px;
+      }
+    </style>
+    <style>
+      div {
+        color: blue;
+      }
+    </style>
+
+    <p>small text</p>
+    <div no-inline>b</div>
+  `)
+  .then(result => result.html)
+```
+
+Result:
+
+```html
+<style>
+  p {
+    font-size: 12px;
+  }
+</style>
+<style>
+  div {
+    color: blue;
+  }
+</style>
+
+<p>small text</p>
+<div>b</div>
+```
+
 
 [npm]: https://www.npmjs.com/package/posthtml-css-inline
 [npm-version-shield]: https://img.shields.io/npm/v/posthtml-css-inline.svg

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,25 @@ const plugin = (options = {}) => {
   return function (tree) {
     options = {...defaultOptions, ...options}
     const promises = []
+    const skipAttributes = new Set(['no-inline', 'data-embed', 'embed', 'prevent-inline', 'skip-inline'])
 
     tree.walk(node => {
+      // Don't inline if node is marked as such
+      if (
+        ['style', 'link'].includes(node.tag)
+        && node.attrs
+        && Object.keys(node.attrs).some(attr => skipAttributes.has(attr))
+      ) {
+        // Delete node attribute
+        for (const attr in node.attrs) {
+          if (skipAttributes.has(attr)) {
+            delete node.attrs[attr]
+          }
+        }
+
+        return node
+      }
+
       // Process <style> tags
       if (node.tag === 'style' && node.content) {
         promises.push(

--- a/lib/processStyleTags.js
+++ b/lib/processStyleTags.js
@@ -10,6 +10,7 @@ const processStyleTags = (node, tree, options = {}) => {
 
     const { postcss: { plugins, ...postcssOptions } } = options
     const safelist = options.safelist || []
+    const skipAttributes = new Set(['no-inline', 'prevent-inline', 'skip-inline'])
 
     // Ensure node.content is array
     node.content = Array.isArray(node.content) ? node.content : [node.content]
@@ -29,6 +30,21 @@ const processStyleTags = (node, tree, options = {}) => {
           }
 
           return tree.match(matchHelper(cssNode.selector), htmlNode => {
+            // Don't inline if node is marked as such
+            if (
+              htmlNode.attrs
+              && Object.keys(htmlNode.attrs).some(attr => skipAttributes.has(attr))
+            ) {
+              // Delete node attribute
+              for (const attr in htmlNode.attrs) {
+                if (skipAttributes.has(attr)) {
+                  delete htmlNode.attrs[attr]
+                }
+              }
+
+              return htmlNode
+            }
+
             extendStyle(htmlNode, cssNode, options)
 
             if (options.removeInlinedSelectors) {

--- a/test/expected/skip.html
+++ b/test/expected/skip.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .flex {
+      display: flex;
+    }
+
+    p {
+      color: red;
+    }
+  </style>
+  <style>div {
+      color: blue;
+    }</style>
+</head>
+<body>
+  <p class="flex">a</p>
+  <div>b</div>
+</body>
+</html>

--- a/test/fixtures/skip.html
+++ b/test/fixtures/skip.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style no-inline>
+    .flex {
+      display: flex;
+    }
+
+    p {
+      color: red;
+    }
+  </style>
+  <style>
+    div {
+      color: blue;
+    }
+  </style>
+</head>
+<body>
+  <p class="flex">a</p>
+  <div no-inline>b</div>
+</body>
+</html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,3 +76,9 @@ test('Safelist', () => {
     safelist: ['body', '.flex']
   })
 })
+
+test.only('Skip inlining', () => {
+  return process('skip', {
+    removeInlinedSelectors: true,
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,7 +77,7 @@ test('Safelist', () => {
   })
 })
 
-test.only('Skip inlining', () => {
+test('Skip inlining', () => {
   return process('skip', {
     removeInlinedSelectors: true,
   })


### PR DESCRIPTION
This PR adds support for a `no-inline` attribute that allows skipping CSS inlining:

- when used on a `<style>` or `<link>` tag, the CSS inside the tag will not be inlined
- when used on any other tag, the inliner will not inline CSS on that tag

You may use any of the following attributes to achieve this on a `<style>` or `<link>` tag:

- `no-inline`
- `data-embed`
- `embed`
- `prevent-inline`
- `skip-inline`

Likewise, you may use any of the following attributes to prevent CSS from being inlined on any other tag:

- `no-inline`
- `prevent-inline`
- `skip-inline`

The attribute will be removed from the tag in the resulting HTML.

For example this:

```html
<style no-inline>
  p {
    font-size: 12px;
  }
</style>
<style>
  div {
    color: blue;
  }
</style>

<p>small text</p>
<div no-inline>b</div>
```

... will be compiled to this:

```html
<style>
  p {
    font-size: 12px;
  }
</style>
<style>
  div {
    color: blue;
  }
</style>

<p>small text</p>
<div>b</div>
```

Closes #9 