### PR TITLE
feat: add `excludedProperties` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TODO:
 - [x] Safelist (selectors that should not be inlined)
 - [x] [Skip inlining](https://github.com/cossssmin/posthtml-css-inline/issues/9) on marked tags
 - [ ] Juice-compatible options
-  - [ ] `excludedProperties`
+  - [x] `excludedProperties`
   - [ ] `resolveCSSVariables`
   - [ ] `applyHeightAttributes`
   - [ ] `applyWidthAttributes`
@@ -107,6 +107,7 @@ You may configure how inlining works by passing an options object to the plugin.
 | [`removeInlinedSelectors`](#removeinlinedselectors) | `boolean` | `false` | Remove selectors that were successfully inlined from both the `<style>` tag and from the HTML body. |
 | [`postcss`](#postcss) | `object` | `{}` | Object to configure PostCSS. |
 | [`safelist`](#safelist) | `array` | `[]` | Array of selectors that should not be inlined. |
+| [`excludedProperties`](#excludedproperties) | `array` | `[]` | Array of CSS properties that should not be inlined. |
 
 ## Attributes
 
@@ -350,6 +351,50 @@ Result:
 <body>
   <p class="flex" style="color: red">small text</p>
 </body>
+```
+
+### `excludedProperties`
+
+Type: `array`\
+Default: `[]`
+
+Array of CSS properties that should not be inlined.
+
+```js
+import posthtml from'posthtml'
+import inlineCss from'posthtml-css-inline'
+
+posthtml([
+  inlineCss({
+    excludedProperties: ['color', 'display']
+  })
+])
+  .process(`
+    <style>
+      p {
+        color: red;
+        display: flex;
+        font-size: 12px;
+      }
+    </style>
+
+    <p>text</p>
+  `)
+  .then(result => result.html)
+```
+
+Result:
+
+```html
+<style>
+  p {
+    color: red;
+    display: flex;
+    font-size: 12px;
+  }
+</style>
+
+<p style="font-size: 12px">text</p>
 ```
 
 ### `no-inline`

--- a/lib/extendStyle.js
+++ b/lib/extendStyle.js
@@ -8,7 +8,9 @@ export function extendStyle(htmlNode, cssNode, options = {}) {
 
   for (const property in parsedCssNode) {
     // Don't inline `excludedProperties`
-    if (options.excludedProperties?.includes(property)) continue
+    if (options.excludedProperties?.includes(property)) {
+      continue
+    }
 
     if (Object.prototype.hasOwnProperty.call(parsedCssNode, property)) {
       const cssValue = parsedCssNode[property]

--- a/lib/extendStyle.js
+++ b/lib/extendStyle.js
@@ -7,6 +7,9 @@ export function extendStyle(htmlNode, cssNode, options = {}) {
   attrs.style = attrs.style || {}
 
   for (const property in parsedCssNode) {
+    // Don't inline `excludedProperties`
+    if (options.excludedProperties?.includes(property)) continue
+
     if (Object.prototype.hasOwnProperty.call(parsedCssNode, property)) {
       const cssValue = parsedCssNode[property]
 

--- a/test/expected/excluded-properties.html
+++ b/test/expected/excluded-properties.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .flex {
+      display: flex;
+    }
+
+    body {
+      color: blue;
+    }
+
+    h1 {
+      color: #000;
+      text-transform: uppercase;
+    }
+
+    p {
+      font-style: italic;
+    }
+  </style>
+</head>
+<body style="">
+  <h1 style="text-transform: uppercase">Heading</h1>
+  <p class="flex" style="font-style: italic">Content</p>
+</body>
+</html>

--- a/test/fixtures/excluded-properties.html
+++ b/test/fixtures/excluded-properties.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .flex {
+      display: flex;
+    }
+
+    body {
+      color: blue;
+    }
+
+    h1 {
+      color: #000;
+      text-transform: uppercase;
+    }
+
+    p {
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+  <h1>Heading</h1>
+  <p class="flex">Content</p>
+</body>
+</html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -82,3 +82,9 @@ test('Skip inlining', () => {
     removeInlinedSelectors: true,
   })
 })
+
+test('excludedProperties', () => {
+  return process('excluded-properties', {
+    excludedProperties: ['color', 'display'],
+  })
+})


### PR DESCRIPTION
This PR adds an `excludedProperties` option that allows defining an array of CSS properties that should not be inlined.

```js
import posthtml from'posthtml'
import inlineCss from'posthtml-css-inline'

posthtml([
  inlineCss({
    excludedProperties: ['color', 'display']
  })
])
  .process(`
    <style>
      p {
        color: red;
        display: flex;
        font-size: 12px;
      }
    </style>

    <p>text</p>
  `)
  .then(result => result.html)
```

Result:

```html
<style>
  p {
    color: red;
    display: flex;
    font-size: 12px;
  }
</style>

<p style="font-size: 12px">text</p>
```