### PR TITLE
feat: support illegal css values

### DIFF
--- a/lib/extendStyle.js
+++ b/lib/extendStyle.js
@@ -17,10 +17,10 @@ export function extendStyle(htmlNode, cssNode, options = {}) {
 
       if (cssValue.includes('!important')) {
         // Keep or discard the `!important` value in the inlined CSS based on the `preserveImportant` option
-        attrs.style[property] = options.preserveImportant ? cssValue : cssValue.replace(' !important', '')
+        attrs.style[property] = options.preserveImportant ? cssValue.trim() : cssValue.replace(' !important', '')
       } else {
         // Only add the CSS value if it doesn't already exist inline
-        attrs.style[property] ||= cssValue
+        attrs.style[property] ||= cssValue.trim()
       }
     }
   }
@@ -39,8 +39,11 @@ export function extendStyle(htmlNode, cssNode, options = {}) {
 
 function parseCssFromNode(cssNode) {
   const css = {}
+
   cssNode.nodes.forEach(node => {
-    css[node.prop] = node.value + (node.important ? ' !important' : '')
+    const nodeProp = node.prop || node.toString().split(':')[0]
+    const nodeValue = node.value ? node.value + (node.important ? ' !important' : '') : node.toString().split(':')[1]
+    css[nodeProp] = nodeValue
   })
 
   return css

--- a/test/expected/illegal-values.html
+++ b/test/expected/illegal-values.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    p {
+      font-style: italic !important;
+      width: {{ width }};
+    }
+  </style>
+</head>
+<body>
+  <p style="font-style: italic; width: {{ width }};">Content</p>
+</body>
+</html>

--- a/test/fixtures/illegal-values.html
+++ b/test/fixtures/illegal-values.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    p {
+      font-style: italic !important;
+      width: {{ width }};
+    }
+  </style>
+</head>
+<body>
+  <p>Content</p>
+</body>
+</html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@ import path from 'node:path'
 import {readFileSync} from 'node:fs'
 import {fileURLToPath} from 'node:url'
 import posthtml from 'posthtml'
-import {expect, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 import plugin from '../lib/index.js'
 import {normalizeNewline} from '../lib/utils.js'
 import removeImportant from './stubs/_removeImportantPlugin.js'
@@ -20,13 +20,6 @@ const process = (name, options, log = false) => {
     .then(html => expect(clean(html)).toBe(clean(expected(name))))
 }
 
-test('Plugin options', () => {
-  return process('options', {
-    preserveImportant: true,
-    recognizeNoValueAttribute: true,
-  })
-})
-
 test('<style> in <head>', () => {
   return process('style-in-head')
 })
@@ -35,46 +28,12 @@ test('<style> in <body>', () => {
   return process('style-in-body')
 })
 
-test('Local <link> tags', () => {
-  return process('link-local', {processLinkTags: true})
-})
-
-test('Remote <link> tags', () => {
-  return process('link-remote', {processLinkTags: true})
-})
-
-test('Remote <link> tags (fail)', async () => {
-  await expect(() => process('link-remote-reject', {processLinkTags: true}))
-    .rejects
-    .toThrowError()
-})
-
 test('Preserves at-rules', () => {
   return process('at-rules')
 })
 
-test('Removes inlined selectors', () => {
-  return process('remove-inlined', {removeInlinedSelectors: true})
-})
-
-test('Works with existing inline styles', () => {
+test('Existing inline styles', () => {
   return process('existing-style-attr')
-})
-
-test('PostCSS plugins', () => {
-  return process('postcss-plugins', {
-    postcss: {
-      plugins: [
-        removeImportant,
-      ],
-    },
-  })
-})
-
-test('Safelist', () => {
-  return process('safelist', {
-    safelist: ['body', '.flex']
-  })
 })
 
 test('Skip inlining', () => {
@@ -83,8 +42,55 @@ test('Skip inlining', () => {
   })
 })
 
-test('excludedProperties', () => {
-  return process('excluded-properties', {
-    excludedProperties: ['color', 'display'],
+test('Illegal values', () => {
+  return process('illegal-values')
+})
+
+describe('Options', () => {
+  test('Sanity check', () => {
+    return process('options', {
+      preserveImportant: true,
+      recognizeNoValueAttribute: true,
+    })
+  })
+
+  test('PostCSS plugins', () => {
+    return process('postcss-plugins', {
+      postcss: {
+        plugins: [
+          removeImportant,
+        ],
+      },
+    })
+  })
+
+  test('processLinkTags (local)', () => {
+    return process('link-local', {processLinkTags: true})
+  })
+
+  test('processLinkTags (remote)', () => {
+    return process('link-remote', {processLinkTags: true})
+  })
+
+  test('processLinkTags (remote, fail)', async () => {
+    await expect(() => process('link-remote-reject', {processLinkTags: true}))
+      .rejects
+      .toThrowError()
+  })
+
+  test('removeInlinedSelectors', () => {
+    return process('remove-inlined', {removeInlinedSelectors: true})
+  })
+
+  test('safelist', () => {
+    return process('safelist', {
+      safelist: ['body', '.flex']
+    })
+  })
+
+  test('excludedProperties', () => {
+    return process('excluded-properties', {
+      excludedProperties: ['color', 'display'],
+    })
   })
 })


### PR DESCRIPTION
This PR adds basic support for 'illegal' CSS values.

For example this:

```html
<style>
  p {
    width: {{ width }};
  }
</style>

<p>Content</p>
```

... will be inlined as expected:

```html
<p style="width: {{ width }};">Content</p>
```

It's "basic" because currently we can't get anything after `}}`, so something like this:

```html
<style>
  p {
    width: {{ width }}px;
  }
</style>

<p>Content</p>
```

... will be inlined without `px`:

```html
<p style="width: {{ width }};">Content</p>
```

There might be other cases where this semi-fails, but for now at least we don't inline something like `undefined: undefined` because that's what happens when PostCSS can't parse a rule (missing `node.prop` and `node.value`).