### PR TITLE
fix: preserve selectors from no-inline elements

### DIFF
--- a/lib/processStyleTags.js
+++ b/lib/processStyleTags.js
@@ -9,7 +9,7 @@ const processStyleTags = (node, tree, options = {}) => {
     const selectorsToRemove = new Set()
 
     const { postcss: { plugins, ...postcssOptions } } = options
-    const safelist = options.safelist || []
+    options.safelist = new Set(options.safelist)
     const skipAttributes = new Set(['no-inline', 'prevent-inline', 'skip-inline'])
 
     // Ensure node.content is array
@@ -25,7 +25,7 @@ const processStyleTags = (node, tree, options = {}) => {
         const sortedCssNodes = sortCssNodesBySpecificity(result.root.nodes)
 
         sortedCssNodes.map(cssNode => {
-          if (safelist.includes(cssNode.selector)) {
+          if (options.safelist.has(cssNode.selector)) {
             return
           }
 
@@ -35,12 +35,15 @@ const processStyleTags = (node, tree, options = {}) => {
               htmlNode.attrs
               && Object.keys(htmlNode.attrs).some(attr => skipAttributes.has(attr))
             ) {
-              // Delete node attribute
-              for (const attr in htmlNode.attrs) {
-                if (skipAttributes.has(attr)) {
-                  delete htmlNode.attrs[attr]
-                }
-              }
+              Object.keys(htmlNode.attrs)
+                .filter(attr => skipAttributes.has(attr))
+                .forEach(attr => {
+                  // Delete node attribute
+                  htmlNode.attrs[attr] = false
+                })
+
+              // Safelist the selector so we don't remove it no matter what
+              options.safelist.add(cssNode.selector)
 
               return htmlNode
             }

--- a/lib/removeInlinedSelectors.js
+++ b/lib/removeInlinedSelectors.js
@@ -7,7 +7,9 @@ const process = ({node, sortedCssNodes, selectorsToRemove, tree, options: plugin
 
   // Update the <style> tag content to include only the selectors that were not inlined
   const css = sortedCssNodes
-    .filter(cssNode => !selectorsToRemove.has(cssNode.selector))
+    .filter(cssNode =>
+      pluginOptions.safelist.has(cssNode.selector) || !selectorsToRemove.has(cssNode.selector)
+    )
     .map(cssNode => cssNode.toString())
     .join(' ')
 
@@ -26,7 +28,11 @@ const process = ({node, sortedCssNodes, selectorsToRemove, tree, options: plugin
 
   // Find selectorsToRemove in HTML and remove them
   sortedCssNodes
-    .filter(cssNode => selectorsToRemove.has(cssNode.selector) && !selectorsToPreserve.has(cssNode.selector))
+    .filter(cssNode =>
+      selectorsToRemove.has(cssNode.selector)
+      && !selectorsToPreserve.has(cssNode.selector)
+      && !pluginOptions.safelist.has(cssNode.selector)
+    )
     .map(cssNode => {
       tree.match(matchHelper(cssNode.selector), htmlNode => {
         // Remove cssNode.selector from htmlNode attrs

--- a/test/expected/skip.html
+++ b/test/expected/skip.html
@@ -10,12 +10,17 @@
       color: red;
     }
   </style>
-  <style>div {
+  <style>#title {
+      color: #000;
+    } .blue {
       color: blue;
+    } .inline {
+      display: inline;
     }</style>
 </head>
 <body>
-  <p class="flex">a</p>
-  <div>b</div>
+  <p class="flex blue" style="color: blue">a</p>
+  <div class="blue inline">b</div>
+  <h1 id="title">Title</h1>
 </body>
 </html>

--- a/test/fixtures/skip.html
+++ b/test/fixtures/skip.html
@@ -11,13 +11,20 @@
     }
   </style>
   <style>
-    div {
+    .blue {
       color: blue;
+    }
+    .inline {
+      display: inline;
+    }
+    #title {
+      color: #000;
     }
   </style>
 </head>
 <body>
-  <p class="flex">a</p>
-  <div no-inline>b</div>
+  <p class="flex blue">a</p>
+  <div class="blue inline" no-inline>b</div>
+  <h1 id="title" no-inline>Title</h1>
 </body>
 </html>


### PR DESCRIPTION
Don't remove them from the `<style>` tag or from the element itself.